### PR TITLE
Enable CMEK on logging bucket

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -12,7 +12,7 @@ repos:
       - id: no-commit-to-branch
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.4
+    rev: v1.83.6
     hooks:
       - id: terraform_fmt
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,10 @@
 # <img align="left" width="45" height="45" src="https://github.com/osinfra-io/terraform-google-cloud-sql/assets/1610100/ef899efa-b2ce-4c31-83cf-debefadd481d"> Security Policy
 
-Open Source Infrastructure (as Code) exposes identifying information that would not be exposed in a traditional 
+Open Source Infrastructure (as Code) exposes identifying information that would not be exposed in a traditional
 private organization to share knowledge and best practices. This is a net positive for
-the community, but it does come with some risks. 
+the community, but it does come with some risks.
 
 ## Reporting a Vulnerability
 
-Privately discuss, fix, and publish information about security vulnerabilities in this repository by drafting a new 
+Privately discuss, fix, and publish information about security vulnerabilities in this repository by drafting a new
 [security advisory](https://github.com/osinfra-io/terraform-google-project/security/advisories/new).

--- a/global/README.md
+++ b/global/README.md
@@ -11,7 +11,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.0.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.6.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
@@ -24,6 +24,9 @@ No modules.
 |------|------|
 | [google_billing_budget.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/billing_budget) | resource |
 | [google_compute_project_metadata_item.enable_oslogin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_project_metadata_item) | resource |
+| [google_kms_crypto_key.cis_2_2_logging_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key) | resource |
+| [google_kms_crypto_key_iam_member.cis_2_2_logging_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_member) | resource |
+| [google_kms_key_ring.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_key_ring) | resource |
 | [google_logging_metric.cis_logging_metrics](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_metric) | resource |
 | [google_logging_project_bucket_config.cis_2_2_logging_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_bucket_config) | resource |
 | [google_logging_project_sink.cis_2_2_logging_sink](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
@@ -34,6 +37,7 @@ No modules.
 | [google_project_iam_member.cis_2_2](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [random_id.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [google_logging_project_cmek_settings.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/logging_project_cmek_settings) | data source |
 
 ## Inputs
 
@@ -42,11 +46,12 @@ No modules.
 | <a name="input_billing_account"></a> [billing\_account](#input\_billing\_account) | The alphanumeric ID of the billing account this project belongs to | `string` | n/a | yes |
 | <a name="input_budget_notification_email"></a> [budget\_notification\_email](#input\_budget\_notification\_email) | The email address to send budget notifications to | `string` | `"billing-admins@osinfra.io"` | no |
 | <a name="input_cis_2_2_logging_bucket_locked"></a> [cis\_2\_2\_logging\_bucket\_locked](#input\_cis\_2\_2\_logging\_bucket\_locked) | Boolean to enable CIS 2.2 logging bucket lock | `bool` | `true` | no |
-| <a name="input_cis_2_2_logging_sink_project_id"></a> [cis\_2\_2\_logging\_sink\_project\_id](#input\_cis\_2\_2\_logging\_sink\_project\_id) | The CIS 2.2 logging sink benchmark project ID | `string` | `""` | no |
+| <a name="input_cis_2_2_logging_sink_project_id"></a> [cis\_2\_2\_logging\_sink\_project\_id](#input\_cis\_2\_2\_logging\_sink\_project\_id) | The CIS 2.2 logging sink project ID | `string` | `""` | no |
 | <a name="input_cost_center"></a> [cost\_center](#input\_cost\_center) | The cost center to label the project with | `string` | n/a | yes |
 | <a name="input_description"></a> [description](#input\_description) | A short description representing the system, or service you're building in the project for example: `tools` (for a tooling project), `logging` (for a logging project), `services` (for a services project) | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment suffix for example: `sb` (Sandbox), `nonprod` (Non-Production), `prod` (Production) | `string` | `"sb"` | no |
 | <a name="input_folder_id"></a> [folder\_id](#input\_folder\_id) | The numeric ID of the folder this project should be created under. Only one of `org_id` or `folder_id` may be specified | `string` | n/a | yes |
+| <a name="input_key_ring_location"></a> [key\_ring\_location](#input\_key\_ring\_location) | The location of the key ring to create | `string` | `"us"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | A set of key/value label pairs to assign to the project | `map(string)` | `{}` | no |
 | <a name="input_monthly_budget_amount"></a> [monthly\_budget\_amount](#input\_monthly\_budget\_amount) | The monthly budget amount in USD to set for the project | `number` | `5` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | The team prefix for example: `ops` (Operations), `sec` (Security) | `string` | `"test"` | no |
@@ -59,6 +64,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_cis_2_2_logging_sink_project_id"></a> [cis\_2\_2\_logging\_sink\_project\_id](#output\_cis\_2\_2\_logging\_sink\_project\_id) | The CIS 2.2 logging sink benchmark project ID |
+| <a name="output_cis_2_2_logging_sink_service_account"></a> [cis\_2\_2\_logging\_sink\_service\_account](#output\_cis\_2\_2\_logging\_sink\_service\_account) | The CIS 2.2 logging sink benchmark service account |
 | <a name="output_cis_logging_metrics_alert_policy_names"></a> [cis\_logging\_metrics\_alert\_policy\_names](#output\_cis\_logging\_metrics\_alert\_policy\_names) | The CIS logging metrics alert policy names, we need these to test the resources with inspec |
 | <a name="output_project_id"></a> [project\_id](#output\_project\_id) | The project ID |
 | <a name="output_project_number"></a> [project\_number](#output\_project\_number) | The project number |

--- a/global/locals.tf
+++ b/global/locals.tf
@@ -106,6 +106,7 @@ locals {
   services = toset(concat(
     var.services,
     [
+      "cloudkms.googleapis.com",
       "logging.googleapis.com"
     ]
   ))

--- a/global/outputs.tf
+++ b/global/outputs.tf
@@ -17,6 +17,11 @@ output "cis_2_2_logging_sink_project_id" {
   value       = local.cis_2_2_logging_sink_project_id
 }
 
+output "cis_2_2_logging_sink_service_account" {
+  description = "The CIS 2.2 logging sink benchmark service account"
+  value       = data.google_logging_project_cmek_settings.this.service_account_id
+}
+
 output "project_id" {
   description = "The project ID"
   value       = google_project.this.project_id

--- a/global/variables.tf
+++ b/global/variables.tf
@@ -20,7 +20,7 @@ variable "cis_2_2_logging_bucket_locked" {
 }
 
 variable "cis_2_2_logging_sink_project_id" {
-  description = "The CIS 2.2 logging sink benchmark project ID"
+  description = "The CIS 2.2 logging sink project ID"
   type        = string
   default     = ""
 }
@@ -44,6 +44,12 @@ variable "environment" {
 variable "folder_id" {
   description = "The numeric ID of the folder this project should be created under. Only one of `org_id` or `folder_id` may be specified"
   type        = string
+}
+
+variable "key_ring_location" {
+  description = "The location of the key ring to create"
+  type        = string
+  default     = "us"
 }
 
 variable "monthly_budget_amount" {

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -29,6 +29,8 @@ suites:
           backend: gcp
           controls:
             - compute_project_info
+            - kms_crypto_key
+            - kms_key_ring
             - logging_sync
             - project_iam_binding
             - project_logging_audit_config
@@ -44,4 +46,6 @@ suites:
         - name: inspec_gcp
           backend: gcp
           controls:
+            - kms_crypto_key
+            - kms_crypto_key_iam_binding
             - logging_project_sync

--- a/test/fixtures/default_project/infracost-usage.yml
+++ b/test/fixtures/default_project/infracost-usage.yml
@@ -1,18 +1,15 @@
-# Infracost Usage File
-# https://www.infracost.io/docs/features/usage_file
-
+# You can use this file to define resource usage estimates for Infracost to use when calculating
+# the cost of usage-based resource, such as AWS S3 or Lambda.
+# `infracost breakdown --usage-file infracost-usage.yml [other flags]`
+# See https://infracost.io/usage-file/ for docs
 version: 0.1
 resource_type_default_usage:
-
-  # The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-
   google_logging_project_sink:
     monthly_logging_data_gb: 10.0 # Monthly logging data in GB.
-
 # resource_usage:
-
-  # The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
-  # All values are commented-out, you can uncomment resources and customize as needed.
-
+  ##
+  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
+  ## All values are commented-out, you can uncomment resources and customize as needed.
+  ##
   # module.test.google_logging_project_sink.cis_2_2_logging_sink:
     # monthly_logging_data_gb: 0.0 # Monthly logging data in GB.

--- a/test/fixtures/default_project/main.tf
+++ b/test/fixtures/default_project/main.tf
@@ -7,7 +7,7 @@
 # - cloudidentity.googleapis.com
 
 provider "google" {
-  billing_project       = "testing-kitchen-tf11-sb"
+  billing_project       = "testing-kitchen-tfd2-sb"
   user_project_override = true
 }
 
@@ -25,7 +25,7 @@ module "test" {
 
   cis_2_2_logging_sink_project_id = "plt-lz-audit01-tf6e-sb" # This project has been created for tests.
   cost_center                     = "x000"
-  description                     = "temp"
+  description                     = "test"
   environment                     = "sb"
   folder_id                       = "1069400145815"
 

--- a/test/fixtures/logging_project/infracost-usage.yml
+++ b/test/fixtures/logging_project/infracost-usage.yml
@@ -1,21 +1,28 @@
-# Infracost Usage File
-# https://www.infracost.io/docs/features/usage_file
-
+# You can use this file to define resource usage estimates for Infracost to use when calculating
+# the cost of usage-based resource, such as AWS S3 or Lambda.
+# `infracost breakdown --usage-file infracost-usage.yml [other flags]`
+# See https://infracost.io/usage-file/ for docs
 version: 0.1
 resource_type_default_usage:
-
-  # The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-
   google_logging_project_bucket_config:
     monthly_logging_data_gb: 100.0 # Monthly logging data in GB.
   google_logging_project_sink:
     monthly_logging_data_gb: 10.0 # Monthly logging data in GB.
-
+  ##
+  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
+  ## All values are commented-out, you can uncomment resource types and customize as needed.
+  ##
+  google_kms_crypto_key:
+    key_versions: 10 # Number of key versions.
+    monthly_key_operations: 100 # Monthly number of key operations.
 # resource_usage:
-
-  # The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
-  # All values are commented-out, you can uncomment resources and customize as needed.
-
+  ##
+  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
+  ## All values are commented-out, you can uncomment resources and customize as needed.
+  ##
+  # module.test.google_kms_crypto_key.cis_2_2_logging_sink[0]:
+    # key_versions: 0 # Number of key versions.
+    # monthly_key_operations: 0 # Monthly number of key operations.
   # module.test.google_logging_project_bucket_config.cis_2_2_logging_sink[0]:
     # monthly_logging_data_gb: 0.0 # Monthly logging data in GB.
   # module.test.google_logging_project_sink.cis_2_2_logging_sink:

--- a/test/fixtures/logging_project/main.tf
+++ b/test/fixtures/logging_project/main.tf
@@ -7,7 +7,7 @@
 # - cloudresourcemanager.googleapis.com
 
 provider "google" {
-  billing_project       = "testing-kitchen-tf11-sb"
+  billing_project       = "testing-kitchen-tfd2-sb"
   user_project_override = true
 }
 
@@ -21,7 +21,7 @@ module "test" {
   billing_account               = var.billing_account
   cis_2_2_logging_bucket_locked = false
   cost_center                   = "x000"
-  description                   = "temp"
+  description                   = "test"
   environment                   = "sb"
   folder_id                     = "1069400145815"
 

--- a/test/fixtures/shared/outputs.tf
+++ b/test/fixtures/shared/outputs.tf
@@ -5,6 +5,10 @@ output "cis_logging_metrics_alert_policy_names" {
   value = module.test.cis_logging_metrics_alert_policy_names
 }
 
+output "cis_2_2_logging_sink_service_account" {
+  value = module.test.cis_2_2_logging_sink_service_account
+}
+
 output "cis_2_2_logging_sink_project_id" {
   value = module.test.cis_2_2_logging_sink_project_id
 }

--- a/test/integration/default_project/controls/gcp_inspec.rb
+++ b/test/integration/default_project/controls/gcp_inspec.rb
@@ -1,7 +1,8 @@
 # Chef InSpec
 # https://www.chef.io/inspec
 
-# Since this is the default test, we want to test as much as possible here and not be redundant in the other tests.
+# Since this is the default test, we want to test as much as possible here and not be
+# redundant in the other tests.
 
 cis_2_2_logging_sink_project_id = input('cis_2_2_logging_sink_project_id')
 project_id = input('project_id')
@@ -32,6 +33,29 @@ control 'compute_project_info' do
   # https://docs.chef.io/inspec/resources/google_compute_project_info
 
   describe google_compute_project_info(project: project_id) do
+    it { should exist }
+  end
+end
+
+control 'kms_crypto_key' do
+  title 'KMS Crypto Key'
+
+  # KMS Crypto Key Resource
+  # https://docs.chef.io/inspec/resources/google_kms_crypto_key
+
+  describe google_kms_crypto_key(project: project_id, location: 'us', key_ring_name: 'default',
+                                 name: 'cis-2-2-logging-sink') do
+    it { should !exist }
+  end
+end
+
+control 'kms_crypto_key_ring' do
+  title 'KMS Crypto Key Ring'
+
+  # KMS Crypto Key Ring Resource
+  # https://docs.chef.io/inspec/resources/google_kms_crypto_key_ring
+
+  describe google_kms_crypto_key_ring(project: project_id, location: 'us', name: 'default') do
     it { should exist }
   end
 end

--- a/test/integration/logging_project/controls/gcp_inspec.rb
+++ b/test/integration/logging_project/controls/gcp_inspec.rb
@@ -1,7 +1,37 @@
 # Chef InSpec
 # https://www.chef.io/inspec
-
+cis_2_2_logging_sink_service_account = input('cis_2_2_logging_sink_service_account')
 project_id = input('project_id')
+
+control 'kms_crypto_key' do
+  title 'KMS Crypto Key'
+
+  # KMS Crypto Key Resource
+  # https://docs.chef.io/inspec/resources/google_kms_crypto_key
+
+  describe google_kms_crypto_key(project: project_id, location: 'us',
+                                 key_ring_name: 'default',
+                                 name: 'cis-2-2-logging-sink') do
+    it { should exist }
+  end
+end
+
+control 'kms_crypto_key_iam_binding' do
+  title 'KMS Crypto Key IAM Binding'
+
+  # KMS Crypto Key IAM Binding Resource
+  # https://docs.chef.io/inspec/resources/google_kms_crypto_key_iam_binding
+
+  describe google_kms_crypto_key_iam_binding(project: project_id, location: 'us',
+                                             key_ring_name: 'default',
+                                             crypto_key_name: 'cis-2-2-logging-sink',
+                                             role: 'roles/cloudkms.cryptoKeyEncrypterDecrypter') do
+    it { should exist }
+    its('members') do
+      should include "serviceAccount:#{cis_2_2_logging_sink_service_account}"
+    end
+  end
+end
 
 control 'logging_project_sync' do
   title 'Logging Project Sync'
@@ -12,6 +42,6 @@ control 'logging_project_sync' do
   describe google_logging_project_sink(project: project_id, name: 'cis-2-2-logging-sink') do
     it { should exist }
     destination = "logging.googleapis.com/projects/#{project_id}"
-    its('destination') { should eq "#{destination}/locations/global/buckets/cis-2-2-logging-sink" }
+    its('destination') { should eq "#{destination}/locations/us/buckets/cis-2-2-logging-sink" }
   end
 end


### PR DESCRIPTION
This pull request enables Customer-Managed Encryption Keys (CMEK) on the logging bucket. By using CMEK, we can have more control over the encryption keys used to protect the data in the bucket. This change ensures that the logging bucket is more secure and compliant with security best practices.

Fixes #65

Fixes #69