### PR TITLE
Upstream `terraform-provider-google` v6.0 sets `deletion_policy` in `google_project` 'PREVENT' by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,6 @@ crash.log
 # be included in version control.
 local.tfvars
 
-# Provider.tf is used for local development of modules and shouldn't be added to repos.
-provider.tf
-
 # Ignore override files as they are usually used to override ressources locally
 override.tf
 override.tf.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.95.0
+    rev: v1.96.1
     hooks:
       - id: terraform_fmt
 
@@ -29,7 +29,7 @@ repos:
       - id: terraform_docs
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.254
+    rev: 3.2.256
     hooks:
       - id: checkov
         verbose: true

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ terraform test
 
 | Name | Version |
 |------|---------|
-| google | 6.2.0 |
+| google | 6.5.0 |
 | random | 3.6.3 |
 
 ### Resources
@@ -116,6 +116,7 @@ terraform test
 | budget\_notification\_email | The email address to send budget notifications to | `string` | `"billing-admins@osinfra.io"` | no |
 | cis\_2\_2\_logging\_bucket\_locked | Boolean to enable CIS 2.2 logging bucket lock | `bool` | `true` | no |
 | cis\_2\_2\_logging\_sink\_project\_id | The CIS 2.2 logging sink project ID | `string` | `""` | no |
+| deletion\_policy | The deletion policy for the project | `string` | `"PREVENT"` | no |
 | description | A short description representing the system, or service you're building in the project for example: `tools` (for a tooling project), `logging` (for a logging project), `services` (for a services project) | `string` | n/a | yes |
 | environment | The environment suffix for example: `sb` (Sandbox), `nonprod` (Non-Production), `prod` (Production) | `string` | `"sb"` | no |
 | folder\_id | The numeric ID of the folder this project should be created under. Only one of `org_id` or `folder_id` may be specified | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -246,6 +246,7 @@ resource "google_project" "this" {
 
   auto_create_network = false
   billing_account     = var.billing_account
+  deletion_policy     = var.deletion_policy
   folder_id           = "folders/${var.folder_id}"
   labels              = var.labels
   name                = local.project_id

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,12 @@ variable "cis_2_2_logging_sink_project_id" {
   default     = ""
 }
 
+variable "deletion_policy" {
+  description = "The deletion policy for the project"
+  type        = string
+  default     = "PREVENT"
+}
+
 variable "description" {
   description = "A short description representing the system, or service you're building in the project for example: `tools` (for a tooling project), `logging` (for a logging project), `services` (for a services project)"
   type        = string


### PR DESCRIPTION
Fixes #130
Fixes #132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new input variable `deletion_policy` for specifying project deletion policies, defaulting to "PREVENT".
	- Enhanced configuration options for Google Cloud resources.

- **Documentation**
	- Updated README.md with clearer instructions and project naming conventions.
	- Updated Terraform provider version from `6.2.0` to `6.5.0`.

- **Chores**
	- Updated versions for pre-commit hooks and repositories to ensure compatibility and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->